### PR TITLE
Add function getValidMovementId

### DIFF
--- a/fdbbackup/backup.actor.cpp
+++ b/fdbbackup/backup.actor.cpp
@@ -2501,16 +2501,16 @@ ACTOR Future<Void> abortDBMove(Optional<Database> src,
 		if (e.code() == error_code_movement_abort_error) {
 			if (destinationAbortError) {
 				if (abortInstruction == AbortState::COMPLETED) {
-					printf("ERROR: The destination movement isn't able to be forced to complete.\n");
+					fprintf(stderr, "ERROR: The destination movement isn't able to be forced to complete.\n");
 				} else if (abortInstruction == AbortState::ROLLED_BACK) {
-					printf("ERROR: The destination movement isn't able to be forced to rollback.\n");
+					fprintf(stderr, "ERROR: The destination movement isn't able to be forced to rollback.\n");
 				}
 			} else {
 				// Error happens in the source abort process
 				if (abortInstruction == AbortState::COMPLETED) {
-					printf("ERROR: The source movement isn't able to be forced to complete.\n");
+					fprintf(stderr, "ERROR: The source movement isn't able to be forced to complete.\n");
 				} else if (abortInstruction == AbortState::ROLLED_BACK) {
-					printf("ERROR: The source movement isn't able to be forced to rollback.\n");
+					fprintf(stderr, "ERROR: The source movement isn't able to be forced to rollback.\n");
 				}
 			}
 		} else if (e.code() == error_code_movement_not_found) {

--- a/fdbbackup/backup.actor.cpp
+++ b/fdbbackup/backup.actor.cpp
@@ -2422,7 +2422,7 @@ ACTOR Future<Void> abortDBMove(Optional<Database> src,
 		int tempIndex = 0;
 		if (src.present()) {
 			if (movementStatuses[tempIndex].get().isError()) {
-				printf("ERROR: The movement on the source cluster has a error: %s\n",
+				printf("ERROR: Could not load the movement details on the source cluster: %s\n",
 				       movementStatuses[tempIndex].get().getError().what());
 				return Void();
 			}
@@ -2430,7 +2430,7 @@ ACTOR Future<Void> abortDBMove(Optional<Database> src,
 		}
 		if (dest.present()) {
 			if (movementStatuses[tempIndex].get().isError()) {
-				printf("ERROR: The movement on the destination cluster has a error: %s\n",
+				printf("ERROR: Could not load the movement details on the destination cluster: %s\n",
 				       movementStatuses[tempIndex].get().getError().what());
 				return Void();
 			}
@@ -2513,8 +2513,13 @@ ACTOR Future<Void> abortDBMove(Optional<Database> src,
 					printf("ERROR: The source movement isn't able to be forced to rollback.\n");
 				}
 			}
+		} else if (e.code() == error_code_movement_not_found) {
+			if (!destinationAbortError) {
+				fprintf(stderr, "ERROR: The data movement record was externally erased during the abort process.");
+			}
+		} else {
+			fprintf(stderr, "ERROR: %s\n", e.what());
 		}
-		fprintf(stderr, "ERROR: %s\n", e.what());
 	}
 
 	return Void();

--- a/fdbbackup/backup.actor.cpp
+++ b/fdbbackup/backup.actor.cpp
@@ -2376,6 +2376,9 @@ ACTOR Future<AbortState> abortDBMove(Database database,
                                      Optional<UID> uid,
                                      AbortState abortInstruction) {
 	state AbortMovementRequest abortMovementRequest(prefix, location);
+	if (uid.present()) {
+		abortMovementRequest.movementId = uid.get();
+	}
 	abortMovementRequest.abortInstruction = abortInstruction;
 	state Future<ErrorOr<AbortMovementReply>> abortMovementReply = Never();
 	state Future<Void> initialize = Void();

--- a/fdbbackup/backup.actor.cpp
+++ b/fdbbackup/backup.actor.cpp
@@ -2422,23 +2422,26 @@ ACTOR Future<Void> abortDBMove(Optional<Database> src,
 		int tempIndex = 0;
 		if (src.present()) {
 			if (movementStatuses[tempIndex].get().isError()) {
-				printf("ERROR: Could not load the movement details on the source cluster: %s\n",
-				       movementStatuses[tempIndex].get().getError().what());
+				fprintf(stderr,
+				        "ERROR: Could not load the movement details on the source cluster: %s\n",
+				        movementStatuses[tempIndex].get().getError().what());
 				return Void();
 			}
 			srcMovementStatus = movementStatuses[tempIndex++].get().get();
 		}
 		if (dest.present()) {
 			if (movementStatuses[tempIndex].get().isError()) {
-				printf("ERROR: Could not load the movement details on the destination cluster: %s\n",
-				       movementStatuses[tempIndex].get().getError().what());
+				fprintf(stderr,
+				        "ERROR: Could not load the movement details on the destination cluster: %s\n",
+				        movementStatuses[tempIndex].get().getError().what());
 				return Void();
 			}
 			destMovementStatus = movementStatuses[tempIndex].get().get();
 		}
 		if (src.present() && dest.present() &&
 		    srcMovementStatus.tenantMovementInfo.movementId != destMovementStatus.tenantMovementInfo.movementId) {
-			printf(
+			fprintf(
+			    stderr,
 			    "ERROR: The data movements taking place on the specified prefixes do not match. The movement id of the "
 			    "source cluster is %s. The movement id of the destination cluster is %s. Confirm that you have "
 			    "specified the correct clusters and prefixes for the movement you wish to abort.\n",

--- a/fdbclient/TenantBalancerInterface.h
+++ b/fdbclient/TenantBalancerInterface.h
@@ -435,7 +435,7 @@ struct AbortMovementReply {
 struct AbortMovementRequest {
 	constexpr static FileIdentifier file_identifier = 14058403;
 
-	Optional<UID> movementId;
+	UID movementId;
 	Key prefix;
 	MovementLocation movementLocation;
 	AbortState abortInstruction = AbortState::UNKNOWN;

--- a/fdbclient/TenantBalancerInterface.h
+++ b/fdbclient/TenantBalancerInterface.h
@@ -435,7 +435,7 @@ struct AbortMovementReply {
 struct AbortMovementRequest {
 	constexpr static FileIdentifier file_identifier = 14058403;
 
-	UID movementId;
+	Optional<UID> movementId;
 	Key prefix;
 	MovementLocation movementLocation;
 	AbortState abortInstruction = AbortState::UNKNOWN;

--- a/fdbclient/TenantBalancerInterface.h
+++ b/fdbclient/TenantBalancerInterface.h
@@ -435,7 +435,7 @@ struct AbortMovementReply {
 struct AbortMovementRequest {
 	constexpr static FileIdentifier file_identifier = 14058403;
 
-	Optional<UID> movementId;
+	UID movementId;
 	Key prefix;
 	MovementLocation movementLocation;
 	AbortState abortInstruction = AbortState::UNKNOWN;
@@ -443,8 +443,6 @@ struct AbortMovementRequest {
 	ReplyPromise<AbortMovementReply> reply;
 
 	AbortMovementRequest() : movementLocation(MovementLocation::SOURCE) {}
-	AbortMovementRequest(Key prefix, MovementLocation movementLocation)
-	  : prefix(prefix), movementLocation(movementLocation) {}
 	AbortMovementRequest(UID movementId, Key prefix, MovementLocation movementLocation)
 	  : movementId(movementId), prefix(prefix), movementLocation(movementLocation) {}
 

--- a/fdbserver/TenantBalancer.actor.cpp
+++ b/fdbserver/TenantBalancer.actor.cpp
@@ -1743,9 +1743,10 @@ ACTOR Future<Void> abortMovement(TenantBalancer* self, AbortMovementRequest req)
 	    .detail("Prefix", req.prefix);
 
 	try {
-		self->getMovementSnapshot(req.movementLocation, req.prefix)->abort(); // abort other in-flight movements
-		Reference<MovementRecordMap::MutableRecord> mutableRecord =
-		    wait(self->mutateMovement(req.movementLocation, req.prefix)); // wait until other finished
+		self->getMovementSnapshot(req.movementLocation, req.prefix, req.movementId)
+		    ->abort(); // abort other in-flight movements
+		Reference<MovementRecordMap::MutableRecord> mutableRecord = wait(self->mutateMovement(
+		    req.movementLocation, req.prefix, req.movementId)); // wait until other operations finished
 		state Reference<MovementRecord> record = mutableRecord->record;
 
 		state AbortState abortResult = AbortState::UNKNOWN;

--- a/flow/error_definitions.h
+++ b/flow/error_definitions.h
@@ -249,7 +249,11 @@ ERROR( movement_not_ready_for_operation, 2395, "The movement is not ready to run
 ERROR( movement_error, 2396, "Movement error")
 ERROR( movement_lag_too_large, 2397, "Movement lag time is too large")
 ERROR( movement_aborted, 2398, "The movement has been aborted")
+<<<<<<< HEAD
 ERROR( movement_abort_error, 2399, "The movement can't be aborted successfully")
+=======
+ERROR( movement_parameter_invalid, 2399, "The parameters are invalid")
+>>>>>>> 0e138db11 (Add function getValidMovementId)
 
 ERROR( key_not_found, 2400, "Expected key is missing")
 ERROR( json_malformed, 2401, "JSON string was malformed")

--- a/flow/error_definitions.h
+++ b/flow/error_definitions.h
@@ -249,14 +249,7 @@ ERROR( movement_not_ready_for_operation, 2395, "The movement is not ready to run
 ERROR( movement_error, 2396, "Movement error")
 ERROR( movement_lag_too_large, 2397, "Movement lag time is too large")
 ERROR( movement_aborted, 2398, "The movement has been aborted")
-<<<<<<< HEAD
-<<<<<<< HEAD
 ERROR( movement_abort_error, 2399, "The movement can't be aborted successfully")
-=======
-ERROR( movement_parameter_invalid, 2399, "The parameters are invalid")
->>>>>>> 0e138db11 (Add function getValidMovementId)
-=======
->>>>>>> 6624d2777 (Use getStatus to acquire the movement record id, and fix log)
 
 ERROR( key_not_found, 2400, "Expected key is missing")
 ERROR( json_malformed, 2401, "JSON string was malformed")

--- a/flow/error_definitions.h
+++ b/flow/error_definitions.h
@@ -250,10 +250,13 @@ ERROR( movement_error, 2396, "Movement error")
 ERROR( movement_lag_too_large, 2397, "Movement lag time is too large")
 ERROR( movement_aborted, 2398, "The movement has been aborted")
 <<<<<<< HEAD
+<<<<<<< HEAD
 ERROR( movement_abort_error, 2399, "The movement can't be aborted successfully")
 =======
 ERROR( movement_parameter_invalid, 2399, "The parameters are invalid")
 >>>>>>> 0e138db11 (Add function getValidMovementId)
+=======
+>>>>>>> 6624d2777 (Use getStatus to acquire the movement record id, and fix log)
 
 ERROR( key_not_found, 2400, "Expected key is missing")
 ERROR( json_malformed, 2401, "JSON string was malformed")


### PR DESCRIPTION
Description
To check whether src and dest prefix belongs to the single movement in abort command function
Testing

Put description here...

# Code-Reviewer Section

The general guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `master` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
